### PR TITLE
[FEATURE] Add signal "BeforeFileDump"

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -95,6 +95,10 @@ class FileDumpHook implements \TYPO3\CMS\Core\Resource\Hook\FileDumpEIDHookInter
 			}
 		}
 
+		/** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
+		$signalSlotDispatcher = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\SignalSlot\Dispatcher');
+		$signalSlotDispatcher->dispatch(__CLASS__, 'BeforeFileDump', array($file, $this));
+
 		// todo: find a nicer way to force the download. Other hooks are blocked by this
 		if (isset($_REQUEST['download'])) {
 			$file->getStorage()->dumpFileContents($file, TRUE);

--- a/Documentation/Misc/Index.rst
+++ b/Documentation/Misc/Index.rst
@@ -52,6 +52,29 @@ To have correct urls to indexed files you need to add/adjust following ext:solr 
 *This feature is sponsored by: STIMME DER HOFFNUNG Adventist Media Center*
 
 
+Signals and slots
+=================
+
+BeforeFileDump
+--------------
+
+This signal will be fired everytime a file is going to download or display. This signal will not be fired, if
+access to requested file is restricted for current logged in frontend user. BeforeFileDump is useful for e.g. tracking access of downloaded files.
+
+Example of how to register a slot for this signal (in your ext_localconf.php):
+
+.. code-block:: php
+
+	/** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
+	$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+	$signalSlotDispatcher->connect(
+		'BeechIt\FalSecuredownload\Hooks\FileDumpHook',
+		'BeforeFileDump',
+		'Vendor\ExtensionName\Slot\BeforeFileDumpSlot',
+		'logFileDump'
+	);
+
+
 Known issues
 ============
 


### PR DESCRIPTION
The new "BeforeFileDump" signal will always be fired, when a file is
going to download/access and the rights allow access.

Example how to register a slot for this signal (in your ext_localconf.php):

```php
/** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
$signalSlotDispatcher->connect(
	'BeechIt\FalSecuredownload\Hooks\FileDumpHook',
	'BeforeFileDump',
	'Vendor\ExtensionName\Slot\BeforeFileDumpSlot',
	'logFileDump'
);
```