### PR TITLE
[FIX] Invoke Correct Condition Check in AssetAccessViewhelper

### DIFF
--- a/Classes/ViewHelpers/Security/AssetAccessViewHelper.php
+++ b/Classes/ViewHelpers/Security/AssetAccessViewHelper.php
@@ -82,4 +82,34 @@ class AssetAccessViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractCon
 		}
 		return $GLOBALS['TSFE']->fe_user->groupData['uid'];
 	}
+
+	/**
+	 * The compiled ViewHelper adds two new ViewHelper arguments: __thenClosure and __elseClosure.
+	 * These contain closures which are be executed to render the then(), respectively else() case.
+	 *
+	 * @param string $argumentsVariableName
+	 * @param string $renderChildrenClosureVariableName
+	 * @param string $initializationPhpCode
+	 * @param \TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode $syntaxTreeNode
+	 * @param \TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler $templateCompiler
+	 * @return string
+	 * @internal
+	 */
+	public function compile(
+		$argumentsVariableName,
+		$renderChildrenClosureVariableName,
+		&$initializationPhpCode,
+		\TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode $syntaxTreeNode,
+		\TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler $templateCompiler
+	) {
+		parent::compile(
+			$argumentsVariableName,
+			$renderChildrenClosureVariableName,
+			$initializationPhpCode,
+			$syntaxTreeNode,
+			$templateCompiler
+		);
+
+		return \TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION;
+	}
 }


### PR DESCRIPTION
Fixes #16

When compiling Viewhelpers which are derived from AbstractconditionViewhelper for caching, the return of `\TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION` assures the condition is checked at runtime when the VH is cached. This overrides default behaviour introduced in https://github.com/TYPO3/TYPO3.CMS/commit/1beb07f03e0dd9316f8bb96d8ef2a75803cda69d