### PR TITLE
[BUGFIX] Prevent SQL error because of missing default value

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -14,7 +14,7 @@ CREATE TABLE tx_falsecuredownload_folder (
 	folder_hash varchar(40) DEFAULT '' NOT NULL,
 
 	# FE permissions
-	fe_groups tinytext NOT NULL,
+	fe_groups tinytext,
 
 	PRIMARY KEY (uid),
 	KEY folder (storage,folder_hash)
@@ -25,7 +25,7 @@ CREATE TABLE tx_falsecuredownload_folder (
 #
 CREATE TABLE sys_file_metadata (
 	# FE permissions
-	fe_groups tinytext NOT NULL
+	fe_groups tinytext,
 );
 
 CREATE TABLE tx_falsecuredownload_download (


### PR DESCRIPTION
Oben a folder in file backend module result in an SQL error because of missing default value.
this change fix it