### PR TITLE
[FEATURE] Add signal to allow custom permission checks

### DIFF
--- a/Classes/Security/CheckPermissions.php
+++ b/Classes/Security/CheckPermissions.php
@@ -53,11 +53,6 @@ class CheckPermissions implements SingletonInterface
     protected $checkFolderRootLineAccessCache = [];
 
     /**
-     * @var array custom groups from slot
-     */
-    protected $customGroups = [];
-
-    /**
      * Constructor
      */
     public function __construct()
@@ -91,15 +86,17 @@ class CheckPermissions implements SingletonInterface
             return true;
         }
 
+        $customUserGroups = [];
         /** @var Dispatcher $signalSlotDispatcher */
         $signalSlotDispatcher = GeneralUtility::makeInstance(Dispatcher::class);
-        $signalSlotDispatcher->dispatch(__CLASS__, 'AddCustomGroups', [&$this]);
+        $signalArguments = $signalSlotDispatcher->dispatch(__CLASS__, 'AddCustomGroups', [$customUserGroups]);
+        $customUserGroups = array_shift($signalArguments);
 
         if (is_array($userFeGroups)) {
-            $userFeGroups = array_unique(array_merge($userFeGroups, $this->customGroups));
+            $userFeGroups = array_unique(array_merge($userFeGroups, $customUserGroups));
         }
-        if ($userFeGroups === false && !empty($this->customGroups)) {
-            $userFeGroups = $this->customGroups;
+        if ($userFeGroups === false && !empty($customUserGroups)) {
+            $userFeGroups = $customUserGroups;
         }
 
         /** @var Folder $parentFolder */
@@ -114,17 +111,6 @@ class CheckPermissions implements SingletonInterface
             return true;
         }
         return false;
-    }
-
-    /**
-     * Add custom groups (needed for adding groups via the slot "AddCustomGroups"
-     *
-     * @param $customGroups
-     * @return void
-     */
-    public function addCustomGroups($customGroups)
-    {
-        $this->customGroups = $customGroups;
     }
 
     /**

--- a/Documentation/Misc/Index.rst
+++ b/Documentation/Misc/Index.rst
@@ -104,6 +104,24 @@ Example of how to register a slot for this signal (in your ext_localconf.php):
 		'logFileDump'
 	);
 
+AddCustomGroups
+---------------
+
+This signal is fired every time, the permissions are checked. It will add new groups to the list of authenticated groups,
+which are not detected by the standard group mechanism. An example is, if you are using ip based authentication, where
+no frontend user is logged in.
+
+The slot must return an array which contains the array of the custom usergroups. This array will then be merged with the
+original array of groups.
+
+.. code-block:: php
+
+     public function addCustomGroups($customGroups)
+     {
+         // add your group ids here
+         return array($customGroups);
+     }
+
 EXT:fal_securedownload vs EXT:naw_securedl
 ==========================================
 


### PR DESCRIPTION
There are extensions, which provide authentication by other measures,
like ip addresses. An example is
https://github.com/einpraegsam/in2frontendauthentication

This signal is used to add custom group uids to provide access to the secured
files.