### PR TITLE
patch downloadname with file extension check

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -202,7 +202,7 @@ class FileDumpHook implements FileDumpEIDHookInterface
         $download_name = $file->getProperty('download_name') ? $file->getProperty('download_name') : $file->getName();
         $file_parts = pathinfo($download_name);
         if( $file_parts['extension'] == '' ){
-        	$download_name = preg_replace( ['/\W/'], ['_'], $download_name ).'.'.$file->getExtension() // append the original extension
+        	$download_name = preg_replace( ['/\W/'], ['_'], $download_name ).'.'.$file->getExtension(); // append the original extension
         }
 
 

--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -201,7 +201,7 @@ class FileDumpHook implements FileDumpEIDHookInterface
         }
 
         $contentDisposition = $asDownload ? 'attachment' : 'inline';
-        header('Content-Disposition: ' . $contentDisposition . '; filename="' . $file->getName() . '"');
+        header('Content-Disposition: ' . $contentDisposition . '; filename="' . ( $file->getProperty('download_name') ? $file->getProperty('download_name') : $file->getName() ) . '"');
         header('Content-Type: ' . $file->getMimeType());
         header('Expires: -1');
         header('Cache-Control: public, must-revalidate, post-check=0, pre-check=0');

--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -199,9 +199,15 @@ class FileDumpHook implements FileDumpEIDHookInterface
             $file->getStorage()->dumpFileContents($file, $asDownload);
             exit;
         }
+        $download_name = $file->getProperty('download_name') ? $file->getProperty('download_name') : $file->getName();
+        $file_parts = pathinfo($download_name);
+        if( $file_parts['extension'] == '' ){
+        	$download_name = preg_replace( ['/\W/'], ['_'], $download_name ).'.'.$file->getExtension() // append the original extension
+        }
+
 
         $contentDisposition = $asDownload ? 'attachment' : 'inline';
-        header('Content-Disposition: ' . $contentDisposition . '; filename="' . ( $file->getProperty('download_name') ? $file->getProperty('download_name') : $file->getName() ) . '"');
+        header('Content-Disposition: ' . $contentDisposition . '; filename="' . $download_name . '"');
         header('Content-Type: ' . $file->getMimeType());
         header('Expires: -1');
         header('Cache-Control: public, must-revalidate, post-check=0, pre-check=0');


### PR DESCRIPTION
ability to set download name over file properties.
adds original file extension if not given in backend.
replaces whitespaces with underscores.