### PR TITLE
Refactor dump file ajax route

### DIFF
--- a/Classes/Aspects/PublicUrlAspect.php
+++ b/Classes/Aspects/PublicUrlAspect.php
@@ -25,7 +25,7 @@ namespace BeechIt\FalSecuredownload\Aspects;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Resource;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -96,11 +96,11 @@ class PublicUrlAspect implements SingletonInterface
             );
 
             // $urlData['publicUrl'] is passed by reference, so we can change that here and the value will be taken into account
-            $urlData['publicUrl'] = BackendUtility::getAjaxUrl(
-                'FalSecuredownload::publicUrl',
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $urlData['publicUrl'] = (string) $uriBuilder->buildUriFromRoute(
+                'ajax_dump_file',
                 $queryParameterArray,
-                false,
-                true
+                UriBuilder::ABSOLUTE_URL
             );
         }
     }

--- a/Classes/Controller/BePublicUrlController.php
+++ b/Classes/Controller/BePublicUrlController.php
@@ -7,7 +7,8 @@ namespace BeechIt\FalSecuredownload\Controller;
  * All code (c) Beech Applications B.V. all rights reserved
  */
 
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Resource\ProcessedFileRepository;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -18,15 +19,14 @@ use TYPO3\CMS\Core\Utility\HttpUtility;
  */
 class BePublicUrlController
 {
-
     /**
      * Dump file content
      * Copy from /sysext/core/Resources/PHP/FileDumpEID.php
-     *
-     * @param array $params
-     * @param AjaxRequestHandler $ajaxObj
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
      */
-    public function dumpFile($params = [], AjaxRequestHandler $ajaxObj = null)
+    public function dumpFile(ServerRequestInterface $request, ResponseInterface $response)
     {
         $parameters = ['eID' => 'dumpFile'];
         if (GeneralUtility::_GP('t')) {

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'dump_file' => [
+        'path' => '/fal_securedownloads/dump_file',
+        'target' => BeechIt\FalSecuredownload\Controller\BePublicUrlController::class . '::dumpFile'
+    ]
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,10 +34,6 @@ if (TYPO3_MODE === 'BE') {
             'generatePublicUrl'
         );
     }
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
-        'FalSecuredownload::publicUrl',
-        \BeechIt\FalSecuredownload\Controller\BePublicUrlController::class . '->dumpFile'
-    );
 
     // Page module hook
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info']['falsecuredownload_filetree']['fal_securedownload'] =


### PR DESCRIPTION
Related to #91
Remove deprecated registerAjaxHandler and make use of new backend ajax
routes introduced with 7.6.