### PR TITLE
Add check for valid file pointer in file dump of resumable downloads

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -218,6 +218,13 @@ class FileDumpHook implements FileDumpEIDHookInterface
             header('Content-Range: bytes */' . $fileSize);
             exit;
         }
+        
+        // Find part of file and push this out
+        $filePointer = @fopen($file->getForLocalProcessing(false), 'rb');
+        if ($filePointer === false) {
+            header('HTTP/1.1 404 File not found');
+            exit;
+        }
 
         $dumpSize = $fileSize;
         list($begin, $end) = $range;
@@ -235,11 +242,6 @@ class FileDumpHook implements FileDumpEIDHookInterface
             ob_end_clean();
         }
 
-        // Find part of file and push this out
-        $filePointer = @fopen($file->getForLocalProcessing(false), 'rb');
-        if ($filePointer === false) {
-            exit;
-        }
         fseek($filePointer, $begin);
         $dumpedSize = 0;
         while (!feof($filePointer) && $dumpedSize < $dumpSize) {

--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -237,6 +237,9 @@ class FileDumpHook implements FileDumpEIDHookInterface
 
         // Find part of file and push this out
         $filePointer = @fopen($file->getForLocalProcessing(false), 'rb');
+        if ($filePointer === false) {
+            exit;
+        }
         fseek($filePointer, $begin);
         $dumpedSize = 0;
         while (!feof($filePointer) && $dumpedSize < $dumpSize) {


### PR DESCRIPTION
If a file is missing but it is not marked as missing in table _sys_file_ the code `@fopen($file->getForLocalProcessing(false), 'rb');` in line 239 will fail and return _false_. The condition `!feof($filePointer) && $dumpedSize < $dumpSize` of the following while loop in line 242 will result in an infinite loop. This could lead to millions and millions of entries in table _sys_log_. Also see PHP documentation for `feof` infinite loop warning: https://www.php.net/manual/en/function.feof.php#refsect1-function.feof-notes