### PR TITLE
[FEATURE] fetch all filemounts for folder select in plugin #122

### DIFF
--- a/Classes/Service/UserFileMountService.php
+++ b/Classes/Service/UserFileMountService.php
@@ -57,8 +57,17 @@ class UserFileMountService extends \TYPO3\CMS\Core\Resource\Service\UserFileMoun
             /** @var $storage \TYPO3\CMS\Core\Resource\ResourceStorage */
             $storage = $storageRepository->findByUid($storageUid);
             if ($storage->isBrowsable()) {
-                $rootLevelFolder = $storage->getRootLevelFolder();
-                $folderItems = $this->getSubfoldersForOptionList($rootLevelFolder);
+                if (!empty($storage->getFileMounts())) {
+                    $fileMounts = $storage->getFileMounts();
+                    $folderItems = [];
+                    foreach ($fileMounts as $fileMount) {
+                        $folderItems[] = $this->getSubfoldersForOptionList($fileMount['folder']);
+                    }
+                    $folderItems = array_merge(...$folderItems);
+                } else {
+                    $rootLevelFolder = $storage->getRootLevelFolder();
+                    $folderItems = $this->getSubfoldersForOptionList($rootLevelFolder);
+                }
                 foreach ($folderItems as $item) {
                     $PA['items'][] = [
                         $item->getIdentifier(),


### PR DESCRIPTION
Hi there,

this PR solves #122 by simply fetching all file mounts if there are any and sub subsequentially fetching the subfolders for each one.

kind regards,
jona