### PR TITLE
Fixing download of files in non-public mounts

### DIFF
--- a/Classes/Controller/BePublicUrlController.php
+++ b/Classes/Controller/BePublicUrlController.php
@@ -26,7 +26,7 @@ class BePublicUrlController
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function dumpFile(ServerRequestInterface $request, ResponseInterface $response)
+    public function dumpFile()
     {
         $parameters = ['eID' => 'dumpFile'];
         if (GeneralUtility::_GP('t')) {


### PR DESCRIPTION
Currently it's not possible to download files in non-public FAL mounts.
![image](https://user-images.githubusercontent.com/915773/68460570-7db18000-0208-11ea-8f24-c9893323495c.png)

This commit fixes the error shown above