### PR TITLE
[BUGFIX] Fix #138: file names with umlauts may download with bad characters in the file name

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -210,7 +210,7 @@ class FileDumpHook implements FileDumpEIDHookInterface
         }
 
         $contentDisposition = $asDownload ? 'attachment' : 'inline';
-        header('Content-Disposition: ' . $contentDisposition . '; filename="' . $downloadName . '"');
+        header('Content-Disposition: ' . $contentDisposition . '; filename=*=UTF-8\'\'' . rawurlencode($downloadName));
         header('Content-Type: ' . $file->getMimeType());
         header('Expires: -1');
         header('Cache-Control: public, must-revalidate, post-check=0, pre-check=0');


### PR DESCRIPTION
Fixed by providing files names in a format compatible with RGC 5987.

This was tested with:
* Safari
* FireFox
* Chrome
* MSEdge