### PR TITLE
[Bugfix] fix PDOStatement::fetch(): Passing null to parameter #1 ($mo…

### DIFF
--- a/Classes/Domain/Repository/ProcessedFileRepository.php
+++ b/Classes/Domain/Repository/ProcessedFileRepository.php
@@ -54,7 +54,7 @@ class ProcessedFileRepository extends \TYPO3\CMS\Core\Resource\ProcessedFileRepo
             ->from($this->table)
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter((int)$uid, \PDO::PARAM_INT)))
             ->execute()
-            ->fetch();
+            ->fetchAssociative();
 
         if (empty($row) || !is_array($row)) {
             throw new \RuntimeException(

--- a/Classes/Hooks/AbstractBeButtons.php
+++ b/Classes/Hooks/AbstractBeButtons.php
@@ -61,6 +61,11 @@ abstract class AbstractBeButtons
     {
         $buttons = [];
 
+        if (!$GLOBALS['BE_USER']->user)
+        {
+            return $buttons;
+        }
+
         // In some folder copy/move actions in file list a invalid id is passed
         try {
             /** @var $file \TYPO3\CMS\Core\Resource\Folder */

--- a/Classes/Service/Utility.php
+++ b/Classes/Service/Utility.php
@@ -66,7 +66,7 @@ class Utility implements SingletonInterface
                 ->where($queryBuilder->expr()->eq('storage', $queryBuilder->createNamedParameter((int)$folder->getStorage()->getUid(), \PDO::PARAM_INT)))
                 ->andWhere($queryBuilder->expr()->eq('folder_hash', $queryBuilder->createNamedParameter($folder->getHashedIdentifier(), \PDO::PARAM_STR)))
                 ->execute()
-                ->fetch();
+                ->fetchAssociative();
 
             // cache results
             self::$folderRecordCache[$folder->getCombinedIdentifier()] = $record;


### PR DESCRIPTION
fixing 
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1476107295: PHP Runtime Deprecation Notice: PDOStatement::fetch(): Passing null to parameter #1 ($mode) of type int is deprecated in /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php line 138 | TYPO3\CMS\Core\Error\Exception thrown in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php in line 137. Requested URL: https://ocalhost/typo3/ajax/filestorage/tree/fetchData?token=--AnonymizedToken-- `