### PR TITLE
[BUGFIX] Fix falsecuredownload_filetree plugin

### DIFF
--- a/Classes/Hooks/CmsLayout.php
+++ b/Classes/Hooks/CmsLayout.php
@@ -128,16 +128,7 @@ class CmsLayout
      */
     protected function getFieldFromFlexform($key, $sheet = 'sDEF')
     {
-        $flexform = $this->flexformData;
-        if (isset($flexform['data'])) {
-            $flexform = $flexform['data'];
-            if (is_array($flexform) && is_array($flexform[$sheet]) && is_array($flexform[$sheet]['lDEF'])
-                && is_array($flexform[$sheet]['lDEF'][$key]) && isset($flexform[$sheet]['lDEF'][$key]['vDEF'])
-            ) {
-                return $flexform[$sheet]['lDEF'][$key]['vDEF'];
-            }
-        }
-        return null;
+        return $this->flexformData['data'][$sheet]['lDEF'][$key]['vDEF'] ?? null;
     }
 
     /**

--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -214,7 +214,11 @@ class FileDumpHook extends AbstractApplication implements FileDumpEIDHookInterfa
      */
     protected function dumpFileContents($file, $asDownload, $resumableDownload)
     {
-        $downloadName = $file->getProperty('download_name') ?: $file->getName();
+        if( $file->hasProperty('download_name') ){
+            $downloadName = $file->getProperty('download_name');
+        } else {
+            $downloadName = $file->getName();
+        }
 
         // Make sure downloadName has a file extension
         $fileParts = pathinfo($downloadName);

--- a/Classes/Service/LeafStateService.php
+++ b/Classes/Service/LeafStateService.php
@@ -86,7 +86,7 @@ class LeafStateService implements SingletonInterface
      */
     protected function getFolderState(FrontendUserAuthentication $user)
     {
-        $folderStates = $user->getKey($user->user['uid'] ? 'user' : 'ses', 'LeafStateService');
+        $folderStates = $user->getKey((!empty($user->user['uid']) && $user->uc !== null) ? 'user' : 'ses', 'LeafStateService');
         if ($folderStates) {
             $folderStates = unserialize($folderStates);
         }
@@ -101,7 +101,7 @@ class LeafStateService implements SingletonInterface
      */
     protected function saveFolderState(FrontendUserAuthentication $user, array $folderState)
     {
-        $user->setKey($user->user['uid'] ? 'user' : 'ses', 'LeafStateService', serialize($folderState));
+        $user->setKey(!empty($user->user['uid']) ? 'user' : 'ses', 'LeafStateService', serialize($folderState));
         $user->storeSessionData();
     }
 }

--- a/Classes/Service/UserFileMountService.php
+++ b/Classes/Service/UserFileMountService.php
@@ -45,7 +45,7 @@ class UserFileMountService extends \TYPO3\CMS\Core\Resource\Service\UserFileMoun
     public function renderFlexFormSelectDropdown(&$PA)
     {
         // get storageUid from flexform
-        $storageUid = $PA['row']['settings.storage'][0];
+        $storageUid = $PA['row']['settings.storage'][0] ?? 0;
 
         // if storageUid found get folders
         if ($storageUid > 0) {

--- a/Classes/ViewHelpers/LeaveStateViewHelper.php
+++ b/Classes/ViewHelpers/LeaveStateViewHelper.php
@@ -50,7 +50,7 @@ class LeaveStateViewHelper extends AbstractConditionViewHelper
         $folder = $arguments['folder'];
 
         $leafStateService = GeneralUtility::makeInstance(LeafStateService::class);
-        $feUser = !empty($GLOBALS['TSFE']) ? $GLOBALS['TSFE']->fe_user : false;
+        $feUser = $GLOBALS['TSFE']->fe_user ?? false;
 
         return $feUser && $leafStateService->getLeafStateForUser($feUser, $folder->getCombinedIdentifier());
     }


### PR DESCRIPTION
Fixes the exception from #184 by adding a additional check to pull request #187 if the property exists.
I did only test the backend until now. Thumbnails do now work with this change.
