### PR TITLE
[TASK] Resolve isRelativeToCurrentScript deprecation

### DIFF
--- a/Classes/EventListener/GeneratePublicUrlForResourceEventListener.php
+++ b/Classes/EventListener/GeneratePublicUrlForResourceEventListener.php
@@ -36,7 +36,7 @@ class GeneratePublicUrlForResourceEventListener
     {
         if (!(Environment::isCli())) {
             $publicUrlAspect = GeneralUtility::makeInstance(PublicUrlAspect::class);
-            $publicUrlAspect->generatePublicUrl($event->getStorage(), $event->getDriver(), $event->getResource(), $event->isRelativeToCurrentScript(), ['publicUrl' => $event->getPublicUrl()]);
+            $publicUrlAspect->generatePublicUrl($event->getStorage(), $event->getDriver(), $event->getResource(), false, ['publicUrl' => $event->getPublicUrl()]);
         }
     }
 }


### PR DESCRIPTION
`GeneratePublicUrlForResourceEvent::isRelativeToCurrentScript` is deprecated since TYPO3 11.3.0.
There parameter is also not used in `PublicUrlAspect::generatePublicUrl`, so we just set it to "false" for now
in order to resolve deprecation notices in TYPO3 log.
The signature of `PublicUrlAspect::generatePublicUrl` should be adjusted next breaking change.