### PR TITLE
[BUGFIX] Don't try to flush output buffers that don't exist

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -275,7 +275,6 @@ class FileDumpHook extends AbstractApplication implements FileDumpEIDHookInterfa
             $buffer = @fread($filePointer, $partSize);
             $dumpedSize += strlen($buffer);
             print $buffer;
-            ob_flush();
             flush();
 
             if (connection_status() !== 0) {


### PR DESCRIPTION
All existing output buffers are closed before dumping the file contents. Calling `ob_flush` again will not have an effect on the buffers, but trigger a warning instead: `Notice: ob_flush(): failed to flush buffer. No buffer to flush`
With exceptionErrors enabled, this will break the eID dumpfile function.