### PR TITLE
FIX: references to core LLL file

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -4,7 +4,7 @@ defined('TYPO3_MODE') or die();
 $additionalColumns = [
     'fe_groups' => [
         'exclude' => true,
-        'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
+        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
         'config' => [
             'type' => 'select',
             'renderType' => 'selectMultipleSideBySide',
@@ -12,11 +12,11 @@ $additionalColumns = [
             'maxitems' => 20,
             'items' => [
                 [
-                    'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.any_login',
+                    'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.any_login',
                     -2
                 ],
                 [
-                    'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.usergroups',
+                    'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.usergroups',
                     '--div--'
                 ]
             ],

--- a/Configuration/TCA/tx_falsecuredownload_folder.php
+++ b/Configuration/TCA/tx_falsecuredownload_folder.php
@@ -58,7 +58,7 @@ return [
         ],
         'fe_groups' => [
             'exclude' => false,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',


### PR DESCRIPTION
This is a fix for version 3.x (TYPO3 10)

Missing labels:

![image](https://user-images.githubusercontent.com/1405149/208407145-50bcbcff-d8c0-4f19-bef6-d9d1cbf32efc.png)
