### PR TITLE
TYPO3 12 Compatibility

### DIFF
--- a/Classes/ContextMenu/ItemProvider.php
+++ b/Classes/ContextMenu/ItemProvider.php
@@ -10,11 +10,12 @@ namespace BeechIt\FalSecuredownload\ContextMenu;
 
 use BeechIt\FalSecuredownload\Service\Utility;
 use TYPO3\CMS\Backend\ContextMenu\ItemProviders\AbstractProvider;
+use TYPO3\CMS\Backend\ContextMenu\ItemProviders\ProviderInterface;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ItemProvider extends AbstractProvider
+class ItemProvider extends AbstractProvider implements ProviderInterface
 {
 
     /**
@@ -97,7 +98,7 @@ class ItemProvider extends AbstractProvider
         $folderRecord = $utility->getFolderRecord($this->folder);
 
         return [
-            'data-callback-module' => 'TYPO3/CMS/FalSecuredownload/ContextMenuActions',
+            'data-callback-module' => '@typo3/fal_securedownload/context-menu-actions',
             'data-folder-record-uid' => $folderRecord['uid'] ?? 0,
             'data-storage' => $this->folder->getStorage()->getUid(),
             'data-folder' => $this->folder->getIdentifier(),

--- a/Classes/Middleware/EidFrontendAuthentication.php
+++ b/Classes/Middleware/EidFrontendAuthentication.php
@@ -52,14 +52,14 @@ class EidFrontendAuthentication implements MiddlewareInterface
         }
 
         // Authenticate now
-        $frontendUser->start();
+        $frontendUser->start($request);
         $frontendUser->unpack_uc();
 
         // Register the frontend user as aspect and within the session
         $this->setFrontendUserAspect($frontendUser);
 
         $backendUserObject = GeneralUtility::makeInstance(FrontendBackendUserAuthentication::class);
-        $backendUserObject->start();
+        $backendUserObject->start($request);
         $backendUserObject->unpack_uc();
         if (!empty($backendUserObject->user['uid'])) {
             $backendUserObject->fetchGroupData();

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'dependencies' => ['backend'],
+    'tags' => [
+        'backend.contextmenu',
+    ],
+    'imports' => [
+        '@typo3/fal_securedownload/' => 'EXT:fal_securedownload/Resources/Public/JavaScript/',
+    ],
+];

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The access to assets can be set on folder/file bases by setting access to fe_gro
 - Keep track of requested downloads (count downloads per user and file)
 
 ### Requirements
-- TYPO3 11 LTS
+- TYPO3 12 LTS
 
 ### Suggestions
-- EXT:ke_search v4.3.1
-- EXT:solrfal v4.1.0
+- ~~EXT:ke_search v4.3.1~~ ATM, EXT:ke_search is not released for TYPO3 12. Suggest using master branch. See https://github.com/tpwd/ke_search
+- ~~EXT:solrfal v4.1.0~~ ATM, EXT:solrfal is not released for TYPO3 12.

--- a/Resources/Public/JavaScript/context-menu-actions.js
+++ b/Resources/Public/JavaScript/context-menu-actions.js
@@ -1,16 +1,12 @@
 /**
- * Module: TYPO3/CMS/FalSecuredownload/ContextMenuActions
+ * Module: @typo3/fal_securedownload/
  *
  * JavaScript to handle the click action of the "FalSecuredownload" context menu item
  * @exports TYPO3/CMS/FalSecuredownload/ContextMenuActions
  */
-define(function () {
-    'use strict';
 
-    /**
-     * @exports TYPO3/CMS/FalSecuredownload/ContextMenuActions
-     */
-    var ContextMenuActions = {};
+
+class ContextMenuActions {
 
     /**
      * Open folder permissions edit form
@@ -18,7 +14,7 @@ define(function () {
      * @param {string} table
      * @param {string} uid combined folder identifier
      */
-    ContextMenuActions.folderPermissions = function (table, uid) {
+     static folderPermissions(table, uid) {
         var folderRecordUid = this.data('folderRecordUid') || 0;
 
         if (folderRecordUid > 0) {
@@ -39,9 +35,9 @@ define(function () {
         }
     };
 
-    ContextMenuActions.getReturnUrl = function () {
+    static getReturnUrl() {
         return encodeURIComponent(top.list_frame.document.location.pathname + top.list_frame.document.location.search);
     };
+};
 
-    return ContextMenuActions;
-});
+export default ContextMenuActions;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "source": "https://github.com/beechit/fal_securedownload"
   },
   "require": {
-    "typo3/cms-core": "^11.5"
+    "typo3/cms-core": "^12.4"
   },
   "replace": {
     "typo3-ter/fal-securedownload": "self.version"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -21,50 +21,43 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['FalSecuredownloadFileTreeState
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FileDumpEID.php']['checkFileAccess']['FalSecuredownload'] =
     \BeechIt\FalSecuredownload\Hooks\FileDumpHook::class;
 
-if (TYPO3_MODE === 'BE') {
+// Page module hook
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info']['falsecuredownload_filetree']['fal_securedownload'] =
+    \BeechIt\FalSecuredownload\Hooks\CmsLayout::class . '->getExtensionSummary';
 
-    // Page module hook
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info']['falsecuredownload_filetree']['fal_securedownload'] =
-        \BeechIt\FalSecuredownload\Hooks\CmsLayout::class . '->getExtensionSummary';
+// Add FolderPermission button to docheader of filelist
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend\Template\Components\ButtonBar']['getButtonsHook']['FalSecuredownload'] =
+    \BeechIt\FalSecuredownload\Hooks\DocHeaderButtonsHook::class . '->getButtons';
 
-    // Add FolderPermission button to docheader of filelist
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend\Template\Components\ButtonBar']['getButtonsHook']['FalSecuredownload'] =
-        \BeechIt\FalSecuredownload\Hooks\DocHeaderButtonsHook::class . '->getButtons';
+// refresh file tree after change in tx_falsecuredownload_folder record
+$GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] =
+    \BeechIt\FalSecuredownload\Hooks\ProcessDatamapHook::class;
+$GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] =
+    \BeechIt\FalSecuredownload\Hooks\ProcessDatamapHook::class;
 
-    // Context menu
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['ContextMenu']['ItemProviders'][1547242135]
-        = \BeechIt\FalSecuredownload\ContextMenu\ItemProvider::class;
+// ext:ke_search custom indexer hook
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFileIndexEntryFromContentIndexer'][] = \BeechIt\FalSecuredownload\Hooks\KeSearchFilesHook::class;
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFileIndexEntry'][] = \BeechIt\FalSecuredownload\Hooks\KeSearchFilesHook::class;
 
-    // refresh file tree after change in tx_falsecuredownload_folder record
-    $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] =
-        \BeechIt\FalSecuredownload\Hooks\ProcessDatamapHook::class;
-    $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] =
-        \BeechIt\FalSecuredownload\Hooks\ProcessDatamapHook::class;
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solrfal')) {
+    /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
+    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
 
-    // ext:ke_search custom indexer hook
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFileIndexEntryFromContentIndexer'][] = \BeechIt\FalSecuredownload\Hooks\KeSearchFilesHook::class;
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFileIndexEntry'][] = \BeechIt\FalSecuredownload\Hooks\KeSearchFilesHook::class;
+    // @Todo convert this to event listener
+    // ext:solrfal enrich metadata and generate correct public url slot
+    $signalSlotDispatcher->connect(
+        \ApacheSolrForTypo3\Solrfal\Indexing\DocumentFactory::class,
+        'fileMetaDataRetrieved',
+        \BeechIt\FalSecuredownload\Aspects\SolrFalAspect::class,
+        'fileMetaDataRetrieved'
+    );
+}
 
-    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solrfal')) {
-        /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
-        $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-
-        // @Todo convert this to event listener
-        // ext:solrfal enrich metadata and generate correct public url slot
-        $signalSlotDispatcher->connect(
-            \ApacheSolrForTypo3\Solrfal\Indexing\DocumentFactory::class,
-            'fileMetaDataRetrieved',
-            \BeechIt\FalSecuredownload\Aspects\SolrFalAspect::class,
-            'fileMetaDataRetrieved'
-        );
-    }
-
-    if (\BeechIt\FalSecuredownload\Configuration\ExtensionConfiguration::trackDownloads()) {
-        // register FormEngine node for rendering download statistics in fe_users
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1470920616] = [
-            'nodeName' => 'falSecureDownloadStats',
-            'priority' => 40,
-            'class' => \BeechIt\FalSecuredownload\FormEngine\DownloadStatistics::class,
-        ];
-    }
+if (\BeechIt\FalSecuredownload\Configuration\ExtensionConfiguration::trackDownloads()) {
+    // register FormEngine node for rendering download statistics in fe_users
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1470920616] = [
+        'nodeName' => 'falSecureDownloadStats',
+        'priority' => 40,
+        'class' => \BeechIt\FalSecuredownload\FormEngine\DownloadStatistics::class,
+    ];
 }


### PR DESCRIPTION
This created TYPO3 12 LTS compatibility. 

In details:
- TYPO3_MODE constant is dropped in TYPO3 12. There is no need for a replacement. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html#typo3-mode-usage-as-global-script-file-security-gate
- Item provider registration via $GLOBALS is not evaluated anmore. See https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Backend/ContextualMenu.html?highlight=data%20callback%20module#item-providers-registration
- Signature of AbstractUserAuthentication::start() has changed. Now, request argument is required.
- ItemProvider needs to implement TYPO3\CMS\Backend\ContextMenu\ItemProviders\ProviderInterface see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96333-ImproveContextMenuItemProviderRegistration.html
-  Javascript AMD Modules are replaced by ES6 modules see https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Backend/JavaScript/ES6/Index.html#backend-javascript-es6


Currently EXT:ke_search and EXT:solrfal aren't available for TYPO3 12. So, at the moment it's not possible to support them. Only ke_search supports TYPO3 12 on the master branch (https://github.com/tpwd/ke_search). But it has not been released and I didn't tested it. I added a comment in the readme file. 

Tested on TYPO3 CMS 12.4.1 and PHP 8.2.5. Seems to work but need further testing.