### PR TITLE
[BUGFIX] Avoid PHP warning for request of eID=FalSecuredownloadFileTreeState

### DIFF
--- a/Classes/Controller/FileTreeStateController.php
+++ b/Classes/Controller/FileTreeStateController.php
@@ -62,12 +62,12 @@ class FileTreeStateController
      */
     public function saveLeafState(ServerRequestInterface $request): ResponseInterface
     {
-        $folder = $request->getParsedBody()['folder'] ?? $request->getQueryParams()['folder'];
+        $folder = $request->getParsedBody()['folder'] ?? $request->getQueryParams()['folder'] ?? null;
         if (empty($folder)) {
             return (new Response())->withStatus(404);
         }
 
-        $open = (bool)($request->getParsedBody()['open'] ?? $request->getQueryParams()['open']);
+        $open = (bool)($request->getParsedBody()['open'] ?? $request->getQueryParams()['open'] ?? false);
         $userAspect = $this->context->getAspect('beechit.user');
         $this->leafStateService->saveLeafStateForUser($userAspect->get('user'), $folder, $open);
 


### PR DESCRIPTION
Avoid "PHP Warning: Undefined array key "folder" in Classes/Controller/FileTreeStateController.php" (and subsequent creation of sys_log record) when requesting /index.php?eID=FalSecuredownloadFileTreeState without a "folder" parameter by defining a default value.

As the same issue might arise for a call to an existing folder requesting without an "open" parameter define a default here too.

These calls usually are triggered by bots calling all URLs found in the site Javascript.