### PR TITLE
FIX: workspace-only users can't set folder permissions

### DIFF
--- a/Configuration/TCA/tx_falsecuredownload_folder.php
+++ b/Configuration/TCA/tx_falsecuredownload_folder.php
@@ -18,6 +18,7 @@ $tca = [
             'ignoreRootLevelRestriction' => true,
         ],
         'iconfile' => 'EXT:fal_securedownload/Resources/Public/Icons/folder.png',
+        'versioningWS_alwaysAllowLiveEdit' => true,
     ],
     'types' => [
         '0' => ['showitem' => 'fe_groups,--palette--;;filePalette'],


### PR DESCRIPTION
For users without permissions for the live WS saving the folder permission fails:

![image](https://github.com/beechit/fal_securedownload/assets/1405149/8ea257a9-1f09-4e75-9c2e-78a968f77002)
