### PR TITLE
FIX: users without permission to modify table see button

### DIFF
--- a/Classes/ContextMenu/ItemProvider.php
+++ b/Classes/ContextMenu/ItemProvider.php
@@ -80,16 +80,18 @@ class ItemProvider extends AbstractProvider
     {
         $this->initialize();
         if ($this->folder instanceof Folder) {
-            $items += $this->prepareItems([
-                'permissions_divider' => [
-                    'type' => 'divider',
-                ],
-                'permissions' => [
-                    'label' => 'LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_be.xlf:clickmenu.folderpermissions',
-                    'iconIdentifier' => 'action-folder',
-                    'callbackAction' => 'folderPermissions',
-                ],
-            ]);
+            if ($this->backendUser->check('tables_modify', 'tx_falsecuredownload_folder')) {
+                $items += $this->prepareItems([
+                    'permissions_divider' => [
+                        'type' => 'divider',
+                    ],
+                    'permissions' => [
+                        'label' => 'LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_be.xlf:clickmenu.folderpermissions',
+                        'iconIdentifier' => 'action-folder',
+                        'callbackAction' => 'folderPermissions',
+                    ],
+                ]);
+            }
         }
 
         return $items;

--- a/Classes/Hooks/AbstractBeButtons.php
+++ b/Classes/Hooks/AbstractBeButtons.php
@@ -79,24 +79,26 @@ abstract class AbstractBeButtons
                 [Folder::ROLE_DEFAULT, Folder::ROLE_USERUPLOAD]
             )
         ) {
-            /** @var Utility $utility */
-            $utility = GeneralUtility::makeInstance(Utility::class);
-            $folderRecord = $utility->getFolderRecord($folder);
+            if ($GLOBALS['BE_USER']->check('tables_modify', 'tx_falsecuredownload_folder')) {
+                /** @var Utility $utility */
+                $utility = GeneralUtility::makeInstance(Utility::class);
+                $folderRecord = $utility->getFolderRecord($folder);
 
-            if ($folderRecord) {
-                $buttons[] = $this->createLink(
-                    $this->sL('clickmenu.folderpermissions'),
-                    $this->sL('clickmenu.folderpermissions'),
-                    $this->getIcon('folder'),
-                    $this->buildEditUrl($folderRecord['uid'])
-                );
-            } else {
-                $buttons[] = $this->createLink(
-                    $this->sL('clickmenu.folderpermissions'),
-                    $this->sL('clickmenu.folderpermissions'),
-                    $this->getIcon('folder'),
-                    $this->buildAddUrl($folder)
-                );
+                if ($folderRecord) {
+                    $buttons[] = $this->createLink(
+                        $this->sL('clickmenu.folderpermissions'),
+                        $this->sL('clickmenu.folderpermissions'),
+                        $this->getIcon('folder'),
+                        $this->buildEditUrl($folderRecord['uid'])
+                    );
+                } else {
+                    $buttons[] = $this->createLink(
+                        $this->sL('clickmenu.folderpermissions'),
+                        $this->sL('clickmenu.folderpermissions'),
+                        $this->getIcon('folder'),
+                        $this->buildAddUrl($folder)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
A user without writing permissions for table `tx_falsecuredownload_folder` should not be able to see these buttons:

![screenshot-www uni-osnabrueck de vm_8000-2024 01 29-15_21_10](https://github.com/beechit/fal_securedownload/assets/1405149/d2423abb-8c4c-4671-b086-b3799efd05c6)
