### PR TITLE
[BUGFIX ] Cache issue in CheckPermissions->checkFolderRootLineAccess

### DIFF
--- a/Classes/Security/CheckPermissions.php
+++ b/Classes/Security/CheckPermissions.php
@@ -162,6 +162,7 @@ class CheckPermissions implements SingletonInterface
     {
         $cacheIdentifier = sha1(
             $folder->getHashedIdentifier() .
+            $folder->getStorage()->getUid() .
             serialize($userFeGroups)
         );
 


### PR DESCRIPTION
Fix for cache issue in CheckPermissions->checkFolderRootLineAccess
see https://github.com/beechit/fal_securedownload/issues/238