### PR TITLE
[TASK] Prevent sys_refindex entries for download stats

### DIFF
--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -41,6 +41,7 @@ class ExtensionConfiguration
     private static bool $forceDownload = false;
     private static string $forceDownloadForExt = '';
     private static bool $trackDownloads = false;
+    private static bool $linkDownloads = false;
     private static bool $resumableDownload = true;
 
     private static function init(): void
@@ -53,6 +54,7 @@ class ExtensionConfiguration
             self::$forceDownload = (bool)$extensionConfig['force_download'];
             self::$forceDownloadForExt = $extensionConfig['force_download_for_ext'];
             self::$trackDownloads = (bool)$extensionConfig['track_downloads'];
+            self::$linkDownloads = isset($extensionConfig['link_downloads']) && $extensionConfig['link_downloads'];
             self::$resumableDownload = isset($extensionConfig['resumable_download']) && $extensionConfig['resumable_download'];
         }
     }
@@ -88,6 +90,17 @@ class ExtensionConfiguration
     {
         self::init();
         return self::$trackDownloads;
+    }
+
+    /**
+     * Link downloads in TCA
+     *
+     * @return bool
+     */
+    public static function linkDownloads(): bool
+    {
+        self::init();
+        return self::$linkDownloads;
     }
 
     public static function resumableDownload(): bool

--- a/Configuration/TCA/tx_falsecuredownload_download.php
+++ b/Configuration/TCA/tx_falsecuredownload_download.php
@@ -34,25 +34,34 @@ $tca = [
             'exclude' => false,
             'label' => 'LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_db.xlf:file',
             'config' => [
-                'type' => 'group',
-                'size' => 1,
-                'maxitems' => 1,
-                'minitems' => 1,
-                'allowed' => 'sys_file',
+                'type' => 'passthrough',
             ],
         ],
         'feuser' => [
             'exclude' => false,
             'label' => 'LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_db.xlf:fe_user',
             'config' => [
-                'type' => 'group',
-                'size' => 1,
-                'maxitems' => 1,
-                'minitems' => 1,
-                'allowed' => 'fe_users',
+                'type' => 'passthrough',
             ],
-        ],
+        ]
     ],
 ];
+
+if (\BeechIt\FalSecuredownload\Configuration\ExtensionConfiguration::linkDownloads()) {
+    $tca['columns']['file']['config'] = [
+        'type' => 'group',
+        'size' => 1,
+        'maxitems' => 1,
+        'minitems' => 1,
+        'allowed' => 'sys_file',
+    ];
+    $tca['columns']['feuser']['config'] = [
+        'type' => 'group',
+        'size' => 1,
+        'maxitems' => 1,
+        'minitems' => 1,
+        'allowed' => 'fe_users',
+    ];
+}
 
 return $tca;

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -43,6 +43,9 @@
 			<trans-unit id="extmng.track_downloads">
 				<source>Count downloads per user and create statistics</source>
 			</trans-unit>
+			<trans-unit id="extmng.link_downloads">
+				<source>Link downloads to files and users in TCA (This will create reference index records for each download)</source>
+			</trans-unit>
 			<trans-unit id="extmng.resumable_download">
 				<source>Enable resumable downloads</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -15,3 +15,6 @@ resumable_download = 1
 
 # cat=basic/enable/6; type=boolean; label=LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_be.xlf:extmng.track_downloads
 track_downloads = 0
+
+# cat=basic/enable/7; type=boolean; label=LLL:EXT:fal_securedownload/Resources/Private/Language/locallang_be.xlf:extmng.link_downloads
+link_downloads = 0


### PR DESCRIPTION
If you do want sys_refindex entries for download stats you can reenable with a new extension configuration variable. When set this will also now create sys_refindex entries when creating the download entries, so a regular reference index update is no longer needed.

Resolves: #243