### PR TITLE
Return instead of exit to return download response to browser in FileDump event listener

### DIFF
--- a/Classes/EventListener/ModifyFileDumpEventListener.php
+++ b/Classes/EventListener/ModifyFileDumpEventListener.php
@@ -187,7 +187,7 @@ class ModifyFileDumpEventListener
         if (!$resumableDownload) {
             $response = $file->getStorage()->streamFile($file, $asDownload, $downloadName);
             $this->event->setResponse($response);
-            exit;
+            return;
         }
 
         $contentDisposition = $asDownload ? 'attachment' : 'inline';


### PR DESCRIPTION
Fixes #251