### PR TITLE
[BUGFIX] Fix: use proper HTTP cache headers for file downloads in Middleware

### DIFF
--- a/Classes/EventListener/ModifyFileDumpEventListener.php
+++ b/Classes/EventListener/ModifyFileDumpEventListener.php
@@ -192,8 +192,9 @@ class ModifyFileDumpEventListener
         $contentDisposition = $asDownload ? 'attachment' : 'inline';
         header('Content-Disposition: ' . $contentDisposition . '; filename="' . $downloadName . '"');
         header('Content-Type: ' . $file->getMimeType());
-        header('Expires: -1');
-        header('Cache-Control: public, must-revalidate, post-check=0, pre-check=0');
+        header('Expires: 0');
+        header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+        header('Pragma: no-cache');
 
         $fileSize = $file->getSize();
         $range = $this->getHttpRange($fileSize);


### PR DESCRIPTION
This PR replaces outdated and non-standard HTTP headers used for file downloads with a secure, standards-compliant set of cache-control directives.

The current implementation uses:
```
header('Expires: -1');
header('Cache-Control: public, must-revalidate, post-check=0, pre-check=0');
```

This combination has several issues:

- Expires: -1 is invalid 
  - The HTTP Expires header must contain a valid HTTP-date (RFC 9111 § 5.3); “-1” is not standard and may be ignored or inconsistently interpreted by browsers and proxies.
- Cache-Control: public allows caching
  -  This enables shared caches (e.g., proxy caches) to store potentially sensitive file downloads.
- post-check / pre-check are obsolete
  - They were Internet Explorer–specific directives and have no effect in modern browsers.
- Mixed semantics 
  - Combining public with must-revalidate and an invalid Expires value leads to unpredictable behavior.

The proposed fix replaces the legacy headers with a modern, RFC-compliant, and OWASP-approved configuration:
```
header('Expires: 0');
header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
header('Pragma: no-cache');
```

This combination:
- Ensures the file is never cached by browsers or shared proxies.
- Uses only valid, current HTTP directives.
- Remains compatible with older HTTP/1.0 clients (Pragma: no-cache).
- Follows OWASP recommendations for preventing caching of sensitive downloads.

References:
- [WSTG-v42-ATHN-06 | Testing for Browser Cache Weaknesses](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/04-Authentication_Testing/06-Testing_for_Browser_Cache_Weaknesses.html)
- [A04:2021 | Insecure Design](https://owasp.org/Top10/A04_2021-Insecure_Design/)
- [CWE-525 | Use of Web Browser Cache Containing Sensitive Information](https://cwe.mitre.org/data/definitions/525.html)